### PR TITLE
Fix CHAR and FLOAT runtime error in Power BI

### DIFF
--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -204,27 +204,22 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
                 OdbcSqlType.REAL = 7,
                 OdbcSqlType.DECIMAL = 3,
 
-                FixDataType = (dataType) =>
-                    if dataType = OdbcSqlType.WCHAR then
-                        OdbcSqlType.WVARCHAR
-                    else if dataType = OdbcSqlType.REAL then
-                        OdbcSqlType.DECIMAL
+                FixColumns = (row) as record =>
+                    if row[TYPE_NAME] = "ENUM" then
+                        Record.TransformFields(row, {
+                            { "DATA_TYPE", (val) => OdbcSqlType.WVARCHAR },
+                            { "TYPE_NAME", (val) => "VARCHAR" }
+                            })
+                    else if row[DATA_TYPE] = OdbcSqlType.REAL then
+                        Record.TransformFields(row, {
+                            { "DATA_TYPE", (val) => OdbcSqlType.DECIMAL },
+                            { "TYPE_NAME", (val) => "DECIMAL" }
+                            })
                     else
-                        dataType,
-                FixTypeName = (typeName) => 
-                    if typeName = "ENUM" then
-                        "VARCHAR"
-                    // All CHAR columns are reported to be VARCHAR as a consequence of the ENUM data type fix,
-                    // which is reported by the driver as dataType = -8 (WCHAR) that Power BI has issues dealing with.
-                    // Sample MariaDB data to test with: flights.carrier (CHAR), employees.gender (ENUM).
-                    else if typeName = "CHAR" then
-                        "VARCHAR"
-                    else if typeName = "FLOAT" then
-                        "DECIMAL"
-                    else
-                        typeName,
-                TransformDataType = Table.TransformColumns(source, { { "DATA_TYPE", FixDataType } }),
-                Transform = Table.TransformColumns(TransformDataType, { { "TYPE_NAME", FixTypeName } })
+                        row,
+                TransformedRows = Table.TransformRows(source, each FixColumns(_)), // column data types info is lost here
+                EmptyTableWithColumnTypes = Table.FirstN(source, 0), // get an empty table with the original column data types
+                Transform = Table.InsertRows(EmptyTableWithColumnTypes, 0, TransformedRows)
             in
                 if (EnableTraceOutput <> true) then Transform else
                 // the if statement conditions will force the values to evaluated/written to diagnostics

--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -201,10 +201,14 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
             let
                 OdbcSqlType.WCHAR = -8,
                 OdbcSqlType.WVARCHAR = -9,
+                OdbcSqlType.REAL = 7,
+                OdbcSqlType.DECIMAL = 3,
 
                 FixDataType = (dataType) =>
                     if dataType = OdbcSqlType.WCHAR then
                         OdbcSqlType.WVARCHAR
+                    else if dataType = OdbcSqlType.REAL then
+                        OdbcSqlType.DECIMAL
                     else
                         dataType,
                 FixTypeName = (typeName) => 
@@ -215,6 +219,8 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
                     // Sample MariaDB data to test with: flights.carrier (CHAR), employees.gender (ENUM).
                     else if typeName = "CHAR" then
                         "VARCHAR"
+                    else if typeName = "FLOAT" then
+                        "DECIMAL"
                     else
                         typeName,
                 TransformDataType = Table.TransformColumns(source, { { "DATA_TYPE", FixDataType } }),

--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -210,6 +210,11 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
                 FixTypeName = (typeName) => 
                     if typeName = "ENUM" then
                         "VARCHAR"
+                    // All CHAR columns are reported to be VARCHAR as a consequence of the ENUM data type fix,
+                    // which is reported by the driver as dataType = -8 (WCHAR) that Power BI has issues dealing with.
+                    // Sample MariaDB data to test with: flights.carrier (CHAR), employees.gender (ENUM).
+                    else if typeName = "CHAR" then
+                        "VARCHAR"
                     else
                         typeName,
                 TransformDataType = Table.TransformColumns(source, { { "DATA_TYPE", FixDataType } }),

--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -278,7 +278,7 @@ MariaDB = [
 
 // Data Source UI publishing description
 MariaDB.Publish = [
-    Beta = true,
+    Beta = false,
     SupportsDirectQuery = true,     // enables direct query
     Category = "Database",
     ButtonText = { Extension.LoadString("ButtonTitle"), Extension.LoadString("ButtonHelp") },

--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -199,10 +199,9 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
         // to the user trace log, without any modification. 
         SQLColumns = (catalogName, schemaName, tableName, columnName, source) =>
             let
-                OdbcSqlType.WCHAR = -8,
                 OdbcSqlType.WVARCHAR = -9,
                 OdbcSqlType.REAL = 7,
-                OdbcSqlType.DECIMAL = 3,
+                OdbcSqlType.DOUBLE = 8,
 
                 FixColumns = (row) as record =>
                     if row[TYPE_NAME] = "ENUM" then
@@ -212,8 +211,8 @@ MariaDBDatabaseImplOdbc = (server as text, optional db as text) as table =>
                             })
                     else if row[DATA_TYPE] = OdbcSqlType.REAL then
                         Record.TransformFields(row, {
-                            { "DATA_TYPE", (val) => OdbcSqlType.DECIMAL },
-                            { "TYPE_NAME", (val) => "DECIMAL" }
+                            { "DATA_TYPE", (val) => OdbcSqlType.DOUBLE },
+                            { "TYPE_NAME", (val) => "DOUBLE" }
                             })
                     else
                         row,

--- a/MariaDB/MariaDB.pq
+++ b/MariaDB/MariaDB.pq
@@ -349,9 +349,13 @@ ODBC = Extension.LoadFunction("OdbcConstants.pqm");
 //     SQL_SC_SQL92_FULL             = 8
 // ]
 //
-// SQL_SC_SQL92_INTERMEDIATE value derived from MariaDB ODBC Connector 3.1.7 sources ma_connection.c:1584
-// 
-Config_SqlConformance = ODBC[SQL_SC][SQL_SC_SQL92_INTERMEDIATE];  // null, 1, 2, 4, 8
+// SQL_SC_SQL92_INTERMEDIATE value was originially derived from MariaDB ODBC Connector 3.1.7 sources ma_connection.c:1584
+// However, during Connecto Certification testing it was found that SQL_SC_SQL92_FULL conformance was required by the Mashup Engine to support joins (JOIN).
+// The SQL92_FULL requirement comes from Microsoft.Mashup.Engine1.Library.Odbc.OdbcQuery.PushDownQuerySpecification(bool liftOrderBy) 
+// where a FoldingFailureException is thrown if DataSource.Info.SupportsDerivedTable == false.
+// Respectively, the property definition in the Mashup Engine was: public virtual bool SupportsDerivedTable => Supports(Odbc32.SQL_SC.SQL_SC_SQL92_FULL);
+// Thus, here SQL92 conformance is reported higher (FULL) than the ODBC driver actually supports or at least reports (INTERMEDIATE).
+Config_SqlConformance = ODBC[SQL_SC][SQL_SC_SQL92_FULL];  // null, 1, 2, 4, 8
 
 // This setting controls row count limits and offsets. If not set correctly, query
 // folding capabilities for this connector will be extremely limited. You can use

--- a/MariaDB/README.txt
+++ b/MariaDB/README.txt
@@ -4,3 +4,12 @@ REQUIREMENTS
 
 - MariaDB ODBC Driver v3.1.7 or later
   https://mariadb.com/kb/en/mariadb-connector-odbc/
+
+
+CHANGE LOG
+
+20-Aug-2020
+- Fixed "joins not working" issue.
+
+12-Aug-2020
+- Disabled tracing as requested by Microsoft.


### PR DESCRIPTION
- Fix for runtime folding error in Power BI Desktop that manifested for CHAR and FLOAT data types with trace log message like:
```
Data Type of column carrier with searchable property UNSEARCHABLE should be SEARCHABLE or ALL_EXCEPT_LIKE.
```
- Fix for the issue with joins.
- Cleared the **Beta** flag. 